### PR TITLE
Checkin Command. (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ The configuration is defined in the config.json example is contained in the root
 
 ## Running
 
-Rotate keys
+Rotate keys - By default the rotate key command will rotate and then escrow the keys.
 
 ```shell
 crypt-bde.exe --config=config.json rotatekey
+```
+
+Checkin - The checkin command will  escrow the current key without rotation, this will not enable bitlocker.
+
+```shell
+crypt-bde.exe --config=config.json checkin
 ```
 
 ### Dont read too much into this.  Just having fun.

--- a/cmd/cryptbde/cryptbde.go
+++ b/cmd/cryptbde/cryptbde.go
@@ -53,6 +53,24 @@ func createVersionCmd() *cobra.Command {
 	return versionCmd
 }
 
+func createCheckinCmd(conf *config.Config) *cobra.Command {
+
+	var checkinCmd = &cobra.Command{
+		Use:   "checkin",
+		Short: "Checkin to the crypt-server",
+		Long: `Checkin to the crypt-server Example:	crypt-bde.exe --config=config.json checkin`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if !conf.Loaded() {
+				fatal(errors.New("config file not loaded. Must specify --config flag"))
+			}
+			if err := crypt.SendCheckin(conf); err != nil {
+				fatal(err)
+			}
+		},
+	}
+	return checkinCmd
+}
+
 func createRootCmd(conf *config.Config) *cobra.Command {
 	// rootCmd represents the base command when called without any subcommands
 	var rootCmd = &cobra.Command{


### PR DESCRIPTION
Accidentally had this on the wrong branch. 

# Background
This should resolve #1 

# Changes 

The following adds a basic command of checkin which is more rotatekey lite.  

# Overview 

Looking at the code. 

Checkin -> SendCheckin -> reports.BuildCheckin -> GetActiveRecoveryPassword. 

Only issue I can see potentially see is checkin should err when there is no Recovery password vs setting it to an empty string.